### PR TITLE
make q close active panel before quitting

### DIFF
--- a/internal/ui/app_update.go
+++ b/internal/ui/app_update.go
@@ -40,11 +40,32 @@ func (m App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		m.copiedName = ""
 		m.warnMsg = ""
-		if msg.String() == keyQuit || msg.String() == keyForceQuit {
+		if msg.String() == keyForceQuit {
 			if m.logs.visible {
 				m = m.closeLogs()
 			}
 			return m, tea.Quit
+		}
+		if msg.String() == keyQuit {
+			switch {
+			case m.logs.visible:
+				m = m.closeLogs()
+				return m, nil
+			case m.inspect.visible:
+				m = m.closeInspect()
+				return m, nil
+			case m.stats.visible:
+				m = m.closeStats()
+				return m, nil
+			case m.events.visible:
+				m = m.closeEvents()
+				return m, nil
+			case m.ctxPicker.visible:
+				m.ctxPicker = ctxPickerState{}
+				return m, nil
+			default:
+				return m, tea.Quit
+			}
 		}
 		if m.logs.visible {
 			return m.handleLogsKey(msg)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -180,7 +180,7 @@ func (m App) helpBar() string {
 				keyStyle.Render("g") + " top · " +
 				keyStyle.Render("G") + " bottom · " +
 				keyStyle.Render("esc") + "/" + keyStyle.Render("v") + " close · " +
-				keyStyle.Render("q") + " quit",
+				keyStyle.Render("q") + " close",
 		)
 	case m.logs.visible:
 		return helpStyle.Render(
@@ -189,7 +189,7 @@ func (m App) helpBar() string {
 				keyStyle.Render("G") + " bottom · " +
 				keyStyle.Render("f") + " toggle all · " +
 				keyStyle.Render("esc") + "/" + keyStyle.Render("l") + " close · " +
-				keyStyle.Render("q") + " quit",
+				keyStyle.Render("q") + " close",
 		)
 	case m.inspect.visible:
 		return helpStyle.Render(
@@ -197,13 +197,13 @@ func (m App) helpBar() string {
 				keyStyle.Render("g") + " top · " +
 				keyStyle.Render("G") + " bottom · " +
 				keyStyle.Render("esc") + "/" + keyStyle.Render("i") + " close · " +
-				keyStyle.Render("q") + " quit",
+				keyStyle.Render("q") + " close",
 		)
 	case m.stats.visible:
 		return helpStyle.Render(
 			"  " + keyStyle.Render("r") + " refresh · " +
 				keyStyle.Render("esc") + "/" + keyStyle.Render("t") + " close · " +
-				keyStyle.Render("q") + " quit",
+				keyStyle.Render("q") + " close",
 		)
 	case m.op == OpConfirming:
 		verb := "Stop"


### PR DESCRIPTION
A shortcut did not do what I expected - my muscle memory is hitting `q` e.g. when logs are open to close the logs tab. This PR addresses that change - hitting `q` first closes open tab, then closes the app.

- When a sub-view (logs, inspect, stats, events, context picker) is open, pressing `q` now closes it instead of quitting the app
- A second `q` with no panel open quits as before
- `ctrl+c` still force-quits immediately
- Help bar updated to show `q` close when a panel is active
