### PR TITLE
request only needed ps fields to avoid per-container size lookup

### DIFF
--- a/internal/docker/cli_containers.go
+++ b/internal/docker/cli_containers.go
@@ -10,9 +10,13 @@ import (
 
 type CLI struct{}
 
+const psFormat = `{"ID":{{json .ID}},"Names":{{json .Names}},"Image":{{json .Image}},` +
+	`"Command":{{json .Command}},"State":{{json .State}},"Status":{{json .Status}},` +
+	`"RunningFor":{{json .RunningFor}},"Ports":{{json .Ports}},"Labels":{{json .Labels}}}`
+
 func (CLI) FetchContainers(all bool) tea.Cmd {
 	return func() tea.Msg {
-		args := []string{"ps", "--format", "{{json .}}"}
+		args := []string{"ps", "--format", psFormat}
 		if all {
 			args = append(args, "-a")
 		}


### PR DESCRIPTION
{{json .}} includes .Size, which makes the CLI request size=1 and the daemon walk layer storage for every container. tdocker doesn't read size, so might as well only request what gets read.

On my host with 80+ containers, this drops startup time from ~7 seconds to 25ms.